### PR TITLE
Resolve ambiguous foreign keys in user profile relationship

### DIFF
--- a/backend/src/models/location.py
+++ b/backend/src/models/location.py
@@ -6,7 +6,7 @@ class ProviderLocation(db.Model):
     __tablename__ = 'provider_locations'
     
     id = db.Column(db.String(36), primary_key=True, default=generate_uuid)
-    provider_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
+    provider_id = db.Column(db.String(36), db.ForeignKey('service_provider_profiles.id'), nullable=False)
     latitude = db.Column(db.Numeric(10, 8), nullable=False)
     longitude = db.Column(db.Numeric(11, 8), nullable=False)
     accuracy = db.Column(db.Numeric(6, 2))  # GPS accuracy in meters

--- a/backend/src/models/service.py
+++ b/backend/src/models/service.py
@@ -96,7 +96,7 @@ class ProviderService(db.Model):
     __tablename__ = 'provider_services'
     
     id = db.Column(db.String(36), primary_key=True, default=generate_uuid)
-    provider_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
+    provider_id = db.Column(db.String(36), db.ForeignKey('service_provider_profiles.id'), nullable=False)
     service_id = db.Column(db.String(36), db.ForeignKey('services.id'), nullable=False)
     custom_price = db.Column(db.Numeric(10, 2))  # Override base price if needed
     is_available = db.Column(db.Boolean, default=True)

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -22,7 +22,8 @@ class User(db.Model):
     
     # Relationships
     customer_profile = db.relationship('CustomerProfile', backref='user', uselist=False, cascade='all, delete-orphan')
-    provider_profile = db.relationship('ServiceProviderProfile', backref='user', uselist=False, cascade='all, delete-orphan')
+    provider_profile = db.relationship('ServiceProviderProfile', foreign_keys='ServiceProviderProfile.user_id', backref='user', uselist=False, cascade='all, delete-orphan')
+    verified_providers = db.relationship('ServiceProviderProfile', foreign_keys='ServiceProviderProfile.verified_by', backref='verifier', lazy='dynamic')
     
     def set_password(self, password):
         """Hash and set password"""
@@ -163,7 +164,7 @@ class CustomerAddress(db.Model):
     __tablename__ = 'customer_addresses'
     
     id = db.Column(db.String(36), primary_key=True, default=generate_uuid)
-    customer_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
+    customer_id = db.Column(db.String(36), db.ForeignKey('customer_profiles.id'), nullable=False)
     address_type = db.Column(db.String(20), default='home')
     address_line1 = db.Column(db.String(255), nullable=False)
     address_line2 = db.Column(db.String(255))


### PR DESCRIPTION
Resolve SQLAlchemy `AmbiguousForeignKeysError` by clarifying foreign key relationships and correcting foreign key references in several models.

The `AmbiguousForeignKeysError` occurred because `ServiceProviderProfile` had multiple foreign keys pointing to the `users` table. This PR explicitly defines the `foreign_keys` for the `User.provider_profile` relationship and introduces a new relationship for `verified_by`. Additionally, it corrects foreign key references in `CustomerAddress`, `ProviderService`, and `ProviderLocation` models to point to their respective profile tables (`customer_profiles`, `service_provider_profiles`) instead of directly to `users`, ensuring proper relationship hierarchy and preventing future ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b9fd849-fb32-4e16-a3c2-9127e59b69e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b9fd849-fb32-4e16-a3c2-9127e59b69e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

