### PR TITLE
Fix egyptian phone number validation

### DIFF
--- a/frontend-web/src/lib/utils.js
+++ b/frontend-web/src/lib/utils.js
@@ -48,8 +48,20 @@ export const formatPhoneNumber = (phone) => {
 
 // Validate Egyptian phone number
 export const isValidEgyptianPhone = (phone) => {
-  const pattern = /^(\+20|0020|20)?1[0-9]{9}$/;
-  return pattern.test(phone.replace(/\s|-/g, ''));
+  // Remove spaces, dashes, and other non-digit characters except +
+  const cleaned = phone.replace(/[\s\-\(\)]/g, '');
+  
+  // Egyptian mobile numbers patterns:
+  // 01xxxxxxxxx (11 digits starting with 01)
+  // +2001xxxxxxxx (with country code)
+  // 002001xxxxxxxx (with country code)
+  const patterns = [
+    /^01[0-9]{9}$/,           // 01xxxxxxxxx (11 digits)
+    /^\+2001[0-9]{9}$/,       // +2001xxxxxxxx
+    /^002001[0-9]{9}$/        // 002001xxxxxxxx
+  ];
+  
+  return patterns.some(pattern => pattern.test(cleaned));
 };
 
 // Validate email


### PR DESCRIPTION
Update Egyptian phone number validation regex to correctly accept valid mobile numbers.

The previous regex `^(\+20|0020|20)?1[0-9]{9}$` incorrectly required the number to start with `1` after an optional country code. This prevented valid Egyptian mobile numbers (which typically start with `01`, `010`, `011`, `012`, `015` after the `0` or country code) from being validated. The updated regex now correctly handles `01xxxxxxxxx`, `+2001xxxxxxxx`, and `002001xxxxxxxx` formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-501bcdf2-a4fc-47ed-90dc-c4f4e119e4ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-501bcdf2-a4fc-47ed-90dc-c4f4e119e4ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

