### PR TITLE
Add dialog title for accessibility

### DIFF
--- a/frontend-admin/src/components/DashboardLayout.jsx
+++ b/frontend-admin/src/components/DashboardLayout.jsx
@@ -15,6 +15,9 @@ import {
   Sheet,
   SheetContent,
   SheetTrigger,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
 } from '@/components/ui/sheet';
 import {
   Home,
@@ -184,6 +187,10 @@ const DashboardLayout = ({ children }) => {
       {/* Mobile Sidebar */}
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
         <SheetContent side="left" className="p-0 w-64">
+          <SheetHeader className="sr-only">
+            <SheetTitle>Navigation Menu</SheetTitle>
+            <SheetDescription>Main navigation for the admin panel</SheetDescription>
+          </SheetHeader>
           <Sidebar />
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
Add hidden `SheetTitle` and `SheetDescription` to mobile sidebar to resolve Radix UI accessibility warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-46f528bf-9d23-4f97-9a5e-836168496891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46f528bf-9d23-4f97-9a5e-836168496891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

