### PR TITLE
Handle provider location foreign key violation

### DIFF
--- a/database/create_tables_fixed.sql
+++ b/database/create_tables_fixed.sql
@@ -169,7 +169,7 @@ CREATE TABLE IF NOT EXISTS provider_services (
 -- Provider locations (real-time tracking)
 CREATE TABLE IF NOT EXISTS provider_locations (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    provider_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_id UUID NOT NULL REFERENCES service_provider_profiles(id) ON DELETE CASCADE,
     latitude DECIMAL(10,8) NOT NULL,
     longitude DECIMAL(11,8) NOT NULL,
     accuracy DECIMAL(6,2),
@@ -183,7 +183,7 @@ CREATE TABLE IF NOT EXISTS provider_locations (
 -- Provider service areas
 CREATE TABLE IF NOT EXISTS provider_service_areas (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    provider_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_id UUID NOT NULL REFERENCES service_provider_profiles(id) ON DELETE CASCADE,
     governorate_id UUID NOT NULL REFERENCES governorates(id) ON DELETE CASCADE,
     city_id UUID REFERENCES cities(id) ON DELETE CASCADE,
     travel_cost DECIMAL(8,2) DEFAULT 0.00,
@@ -196,7 +196,7 @@ CREATE TABLE IF NOT EXISTS provider_service_areas (
 -- Provider documents (for verification)
 CREATE TABLE IF NOT EXISTS provider_documents (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    provider_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_id UUID NOT NULL REFERENCES service_provider_profiles(id) ON DELETE CASCADE,
     document_type VARCHAR(50) NOT NULL CHECK (document_type IN ('national_id', 'business_license', 'tax_certificate', 'insurance', 'certification', 'other')),
     document_url TEXT NOT NULL,
     document_number VARCHAR(100),

--- a/database/supabase_setup.sql
+++ b/database/supabase_setup.sql
@@ -180,7 +180,7 @@ CREATE TABLE booking_status_history (
 -- Provider locations (for tracking)
 CREATE TABLE provider_locations (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    provider_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    provider_id UUID REFERENCES service_provider_profiles(id) ON DELETE CASCADE,
     latitude DECIMAL(10, 8) NOT NULL,
     longitude DECIMAL(11, 8) NOT NULL,
     accuracy DECIMAL(8, 2),
@@ -195,7 +195,7 @@ CREATE TABLE booking_reviews (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     booking_id UUID REFERENCES bookings(id) ON DELETE CASCADE,
     customer_id UUID REFERENCES users(id) ON DELETE CASCADE,
-    provider_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    provider_id UUID REFERENCES service_provider_profiles(id) ON DELETE CASCADE,
     rating INTEGER CHECK (rating >= 1 AND rating <= 5),
     review_text TEXT,
     service_quality_rating INTEGER CHECK (service_quality_rating >= 1 AND service_quality_rating <= 5),


### PR DESCRIPTION
Aligns provider-related table foreign keys to `service_provider_profiles.id` to resolve `ForeignKeyViolation` errors.

The application was attempting to insert `service_provider_profiles.id` into columns (e.g., `provider_locations.provider_id`) that were mistakenly configured in the database to reference `users.id`. This PR corrects these foreign key definitions and provides a migration script.

---
<a href="https://cursor.com/background-agent?bcId=bc-50a07908-b57c-4b42-8cd7-0dae041a6296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-50a07908-b57c-4b42-8cd7-0dae041a6296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

