### PR TITLE
Handle provider location foreign key violation

### DIFF
--- a/backend/src/models/location.py
+++ b/backend/src/models/location.py
@@ -6,7 +6,7 @@ class ProviderLocation(db.Model):
     __tablename__ = 'provider_locations'
     
     id = db.Column(db.String(36), primary_key=True, default=generate_uuid)
-    provider_id = db.Column(db.String(36), db.ForeignKey('service_provider_profiles.id'), nullable=False)
+    provider_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
     latitude = db.Column(db.Numeric(10, 8), nullable=False)
     longitude = db.Column(db.Numeric(11, 8), nullable=False)
     accuracy = db.Column(db.Numeric(6, 2))  # GPS accuracy in meters

--- a/backend/src/routes/providers_updated.py
+++ b/backend/src/routes/providers_updated.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify
 from datetime import datetime
 from src.models import db
-from src.models.user import ServiceProviderProfile, ProviderDocument
+from src.models.user import User, ServiceProviderProfile, ProviderDocument
 from src.models.service import ProviderService, Service
 from src.models.location import ProviderLocation, ProviderServiceArea
 from src.utils.auth import token_required, provider_required, admin_required
@@ -254,8 +254,11 @@ def get_online_providers():
         
         # Base query for online providers
         query = db.session.query(ServiceProviderProfile).join(
+            User,
+            ServiceProviderProfile.user_id == User.id
+        ).join(
             ProviderLocation,
-            ServiceProviderProfile.id == ProviderLocation.provider_id
+            User.id == ProviderLocation.provider_id
         ).filter(
             ServiceProviderProfile.verification_status == 'approved',
             ServiceProviderProfile.is_available == True,
@@ -283,8 +286,11 @@ def get_online_providers():
             ProviderLocation.longitude,
             ProviderLocation.created_at
         ).join(
+            User,
+            ServiceProviderProfile.user_id == User.id
+        ).join(
             ProviderLocation,
-            ServiceProviderProfile.id == ProviderLocation.provider_id
+            User.id == ProviderLocation.provider_id
         ).join(
             subquery,
             db.and_(

--- a/fix_foreign_key_constraint.md
+++ b/fix_foreign_key_constraint.md
@@ -1,0 +1,99 @@
+# Foreign Key Constraint Fix - provider_locations Table
+
+## Problem Summary
+
+The application was failing with a foreign key constraint violation:
+
+```
+(psycopg2.errors.ForeignKeyViolation) insert or update on table "provider_locations" violates foreign key constraint "provider_locations_provider_id_fkey"
+DETAIL: Key (provider_id)=(9033233d-250f-4768-97af-0c3e8f461c82) is not present in table "users".
+```
+
+## Root Cause Analysis
+
+There was a mismatch between the Python model and the database schema:
+
+1. **Python Model** (`backend/src/models/location.py:9`): 
+   ```python
+   provider_id = db.Column(db.String(36), db.ForeignKey('service_provider_profiles.id'), nullable=False)
+   ```
+
+2. **Database Schema** (`database/supabase_setup.sql:183`):
+   ```sql
+   provider_id UUID REFERENCES users(id) ON DELETE CASCADE,
+   ```
+
+3. **Code Logic** (`backend/src/routes/providers.py:224`):
+   ```python
+   provider_id=current_user.provider_profile.id  # This is the service_provider_profiles.id
+   ```
+
+The code was using `current_user.provider_profile.id` (which exists in `service_provider_profiles` table) but the database constraint expected the `provider_id` to reference `users.id`.
+
+## Solution Applied
+
+### 1. Updated Python Code
+Changed all instances of using `current_user.provider_profile.id` to `current_user.id` for ProviderLocation operations:
+
+**Files modified:**
+- `/workspace/backend/src/routes/providers.py` (4 instances)
+- `/workspace/backend/src/routes/providers_updated.py` (2 instances)
+
+### 2. Updated Python Model
+Changed the foreign key reference in the ProviderLocation model:
+
+**File:** `/workspace/backend/src/models/location.py`
+```python
+# Before:
+provider_id = db.Column(db.String(36), db.ForeignKey('service_provider_profiles.id'), nullable=False)
+
+# After:  
+provider_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
+```
+
+### 3. Fixed Database Queries
+Updated join logic in provider queries to properly link through the User table:
+
+**Before:**
+```python
+ServiceProviderProfile.id == ProviderLocation.provider_id
+```
+
+**After:**
+```python
+ServiceProviderProfile.user_id == User.id
+User.id == ProviderLocation.provider_id
+```
+
+## Database Schema Consistency
+
+The fix aligns with the existing database pattern where most provider-related tables reference `users.id`:
+
+- ✅ `provider_locations.provider_id` → `users.id`
+- ✅ `bookings.provider_id` → `users.id` 
+- ✅ `booking_reviews.provider_id` → `users.id`
+- ✅ `payment_transactions.provider_id` → `users.id`
+- ✅ `provider_documents.provider_id` → `service_provider_profiles.id` (exception - correctly designed)
+
+## Additional Schema Fixes Needed
+
+The database may still be missing some columns that the Python model expects. Apply this script to add missing columns:
+
+```sql
+-- Run: /workspace/database/fix_provider_locations_table.sql
+```
+
+This adds:
+- `is_online BOOLEAN DEFAULT true`
+- `battery_level INTEGER`  
+- `last_updated TIMESTAMP WITH TIME ZONE`
+
+## Testing
+
+After applying these fixes, the location update API calls should work correctly:
+
+1. **Provider status updates** (`POST /providers/status`)
+2. **Location updates** (`POST /providers/location`)  
+3. **Live location tracking** (`POST /providers/live-location`)
+
+The foreign key constraint error should be resolved as the `provider_id` will now correctly reference valid `users.id` values.


### PR DESCRIPTION
Fixes foreign key violation in `provider_locations` by aligning Python models and code with the database schema's `users.id` reference.

The `provider_locations` table's `provider_id` was incorrectly referencing `service_provider_profiles.id` in the Python model and application code, while the database schema explicitly required it to reference `users.id`. This led to `ForeignKeyViolation` errors when attempting to insert location data for providers whose `service_provider_profile.id` did not match a `users.id`.

---
<a href="https://cursor.com/background-agent?bcId=bc-19681c5d-4250-44cf-a227-752a5f403893">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19681c5d-4250-44cf-a227-752a5f403893">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

