### PR TITLE
Fix customer locations foreign key datatype mismatch

### DIFF
--- a/backend/src/models/location.py
+++ b/backend/src/models/location.py
@@ -1,5 +1,7 @@
 from src.models import db, generate_uuid
 from datetime import datetime
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
 
 class ProviderLocation(db.Model):
     """Real-time service provider location tracking"""
@@ -151,8 +153,8 @@ class CustomerLocation(db.Model):
     """Customer live location tracking for better service matching"""
     __tablename__ = 'customer_locations'
     
-    id = db.Column(db.String(36), primary_key=True, default=generate_uuid)
-    customer_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    customer_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=False)
     latitude = db.Column(db.Numeric(10, 8), nullable=False)
     longitude = db.Column(db.Numeric(11, 8), nullable=False)
     accuracy = db.Column(db.Numeric(6, 2))  # GPS accuracy in meters

--- a/supabase_customer_locations.sql
+++ b/supabase_customer_locations.sql
@@ -1,0 +1,66 @@
+-- Supabase Customer Locations Table Creation
+-- Run this in your Supabase SQL Editor
+
+-- 1. Create the customer_locations table
+CREATE TABLE IF NOT EXISTS public.customer_locations (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    customer_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    latitude NUMERIC(10, 8) NOT NULL,
+    longitude NUMERIC(11, 8) NOT NULL,
+    accuracy NUMERIC(6, 2),
+    address_components JSONB,
+    formatted_address TEXT,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    last_updated TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 2. Create indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_customer_locations_customer_id ON public.customer_locations(customer_id);
+CREATE INDEX IF NOT EXISTS idx_customer_locations_active ON public.customer_locations(is_active);
+CREATE INDEX IF NOT EXISTS idx_customer_locations_updated ON public.customer_locations(last_updated DESC);
+
+-- 3. Optional: Create GIN index for JSONB address_components (uncomment if needed)
+-- CREATE INDEX IF NOT EXISTS idx_customer_locations_address_gin ON public.customer_locations USING GIN (address_components);
+
+-- 4. Create trigger function for auto-updating last_updated
+CREATE OR REPLACE FUNCTION public.update_customer_locations_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.last_updated = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 5. Create the trigger
+DROP TRIGGER IF EXISTS trigger_customer_locations_updated_at ON public.customer_locations;
+CREATE TRIGGER trigger_customer_locations_updated_at
+    BEFORE UPDATE ON public.customer_locations
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_customer_locations_updated_at();
+
+-- 6. Enable Row Level Security (RLS) - Important for Supabase
+ALTER TABLE public.customer_locations ENABLE ROW LEVEL SECURITY;
+
+-- 7. Create RLS policies
+-- Policy: Users can only see their own location data
+CREATE POLICY "Users can view their own locations" ON public.customer_locations
+    FOR SELECT USING (auth.uid() = customer_id);
+
+-- Policy: Users can insert their own location data
+CREATE POLICY "Users can insert their own locations" ON public.customer_locations
+    FOR INSERT WITH CHECK (auth.uid() = customer_id);
+
+-- Policy: Users can update their own location data
+CREATE POLICY "Users can update their own locations" ON public.customer_locations
+    FOR UPDATE USING (auth.uid() = customer_id);
+
+-- Policy: Users can delete their own location data
+CREATE POLICY "Users can delete their own locations" ON public.customer_locations
+    FOR DELETE USING (auth.uid() = customer_id);
+
+-- 8. Add table comment
+COMMENT ON TABLE public.customer_locations IS 'Customer live location tracking for better service provider matching';
+
+-- 9. Verify the table was created successfully
+SELECT 'customer_locations table created successfully in Supabase!' AS status;


### PR DESCRIPTION
Align `customer_locations` table and model UUID types with `users` table to resolve foreign key datatype mismatch error during table creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-afe809ab-1acc-4e37-9b71-5db2a74d24e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afe809ab-1acc-4e37-9b71-5db2a74d24e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

